### PR TITLE
Modified save_thresholds parameter

### DIFF
--- a/run_icclim.py
+++ b/run_icclim.py
@@ -120,7 +120,7 @@ def main(args):
         slice_mode=args.slice_mode,
         base_period_time_range=base_period,
         logs_verbosity='HIGH',
-        save_thresholds=True,
+        save_thresholds=args.save_thresh,
     )
 
     if args.local_cluster:
@@ -267,6 +267,12 @@ if __name__ == '__main__':
         action='store_true',
         default=False,
         help='Drop the time bounds from output file',
+    )
+    arg_parser.add_argument(
+	"--save_thresh",
+	action='store_true',
+	default=False,
+	help='Save threshold values to output file',
     )
     args = arg_parser.parse_args()
 


### PR DESCRIPTION
`save_thresholds=True` was breaking the script for non-percentile indices. I've modified it to be False by default and then use the `--save_thresh` argument/parameter for percentile indices.